### PR TITLE
Add download script for model files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Model files
+model/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repostitory contains a Python implementation of the functions around the [c
 To use the CiRA pipeline, perform the following steps:
 
 1. Install all required dependencies via `pip3 install -r requirements.txt`.
-2. Download the pre-trained [classification](https://zenodo.org/record/5159501#.Ytq28ITP3-g) and [labeling](https://zenodo.org/record/5550387#.Ytq3QYTP3-g) models.
+2. Download the pre-trained [classification](https://zenodo.org/record/5159501#.Ytq28ITP3-g) and [labeling](https://zenodo.org/record/5550387#.Ytq3QYTP3-g) models or use the `download-models.sh` script.
     - Use the model named `roberta_dropout_linear_layer_multilabel.ckpt` for optimal performance.
     - The location, at which the models are stored locally, is irrelevant.
 3. Optionally, create a `.env` file and specify the variables `MODEL_CLASSIFICATION` and `MODEL_LABELING` with the location of the respective models.

--- a/download-models.sh
+++ b/download-models.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+FILE_CLASSIFIER='model/bertclassifier.bin'
+FILE_CHECKPOINTS='model/checkpoints.zip'
+
+if [ -e $FILE_CLASSIFIER ]; then
+  echo "$FILE_CLASSIFIER already exists"
+else
+  echo "Download $FILE_CLASSIFIER"
+  curl -# "https://zenodo.org/record/5159501/files/bertclassifier.bin?download=1" -o $FILE_CLASSIFIER --create-dirs
+fi
+
+if [ -e $FILE_CHECKPOINTS ]; then
+  echo "$FILE_CHECKPOINTS already exists"
+else
+  echo "Download $FILE_CHECKPOINTS"
+  curl -# "https://zenodo.org/record/5550387/files/checkpoints.zip?download=1" -o $FILE_CHECKPOINTS --create-dirs
+  echo "Extract $FILE_CHECKPOINTS"
+  unzip $FILE_CHECKPOINTS -d model
+fi
+


### PR DESCRIPTION
This PR adds the `download-models.sh` script which will download the required models if they are not present in the `model` folder.