### PR TITLE
Adjust Dockerfile to use new model files (issue #15)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,6 @@
 		}
 	},
 	"containerEnv": {
-		"DEV_CONTAINER": "TRUE",
-		"MODEL_CLASSIFICATION_DEV": "/app/model/bertclassifier.bin",
-		"MODEL_LABELING_DEV": "/app/model/roberta_dropout_linear_layer_multilabel.ckpt"
+		"DEV_CONTAINER": "TRUE"
 	}
 }

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,11 +6,11 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /app
 
-COPY ./model/bertclassifier.bin model/bertclassifier.bin
-COPY ./model/checkpoints/*/roberta_dropout_linear_layer_multilabel.ckpt model/roberta_dropout_linear_layer_multilabel.ckpt
+COPY ./model/cira-classifier.bin model/cira-classifier.bin
+COPY ./model/cira-labeler.ckpt model/cira-labeler.ckpt
 
-ENV MODEL_CLASSIFICATION_DEV=/app/model/bertclassifier.bin
-ENV MODEL_LABELING_DEV=/app/model/roberta_dropout_linear_layer_multilabel.ckpt
+ENV MODEL_CLASSIFICATION_DEV=/app/model/cira-classifier.bin
+ENV MODEL_LABELING_DEV=/app/model/cira-labeler.ckpt
 
 # Required for Jupyter
 RUN pip3 install ipykernel


### PR DESCRIPTION
Due to changes related to issue #15  the Dockerifle uses the wrong file names.
This PR adjusts the Dockerfile so that is uses the correct files provided by `download-models.sh`.

Furthermore, ENV settings in `devcontainer.json` are reduntant with ENV settings in the Dockerfile.