### PR TITLE
Add CI workflow to run Pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,23 @@
+name: Pytest
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    container: andib/cira-dev:latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test with pytest
+      run: |
+        pytest


### PR DESCRIPTION
This PR adds a CI workflow to run `pytest` on the codebase.
This workflow runs in a Docker container based on `Dockerfile.dev` and thus does not require installing dependencies before running `pytest`.