### PR TITLE
API Containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM andib/cira-dev
+
+WORKDIR /cira
+
+# Install missing Python dependencies
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY ./src ./src
+COPY ./app.py ./app.py
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -13,16 +13,20 @@ This repostitory contains a Python implementation of the functions around the [c
 3. Transforming a labeled sentence into a cause-effect graph representing the causal relationship.
 4. Transforming a cause-effect graph into a minimal set of test cases (test suite) asserting the behavior implied by the sentence.
 
-## Prerequisites
+## Development
 
-This package is built and tested using [Python 3.10.0](https://www.python.org/downloads/release/python-3100/). To use the CiRA pipeline, perform the following steps:
+### Setup
+
+#### Local Development
+
+This package is built and tested using [Python 3.10.0](https://www.python.org/downloads/release/python-3100/). To use the CiRA pipeline locally, perform the following steps:
 
 1. Make sure the [Rust compiler](https://www.rust-lang.org/tools/install) is installed on your system, as the `tokenizer` package depends on it.
 2. Install all required dependencies via `pip3 install -r requirements.txt`.
 3. Download and unzip the pre-trained [classification and labeling models](https://doi.org/10.5281/zenodo.7186287) or use the `download-models.sh` script.
 4. Create a `.env` file and specify the variables `MODEL_CLASSIFICATION` and `MODEL_LABELING` with the location of the respective models.
 
-## Development inside a Docker Container
+#### Development inside a Docker Container
 
 You can develop inside a Docker container using a [pre-build image](https://hub.docker.com/r/andib/cira-dev) that contains all dependencies and the recommended classification and labeling models.
 
@@ -35,6 +39,16 @@ For this setup, you need
 Use then the `Remote-Containers: Open Workspace in Container...` command to open the project inside the container.
 
 You can find detailed information about the development container setup [here](https://code.visualstudio.com/docs/remote/containers).
+
+### Usage
+
+To use the CiRA pipeline, instantiate a `src.cira.CiRAConverter` object and specify the location of the pre-trained models. Then, use the high-level functionality as shown in the [demonstration.ipynb](./demonstration.ipynb) file.
+
+## Dockerization
+
+### REST API
+
+The CiRA functionality can also be provided by a single Docker container based on `Dockerfile`. Create the image and run the container via `docker-compose up --build`. The functionality can then be accessed at `localhost:8080`. Check `localhost:8080\docs` while the container is running to access the specification of the API.
 
 ### Building the cira-dev base image
 
@@ -49,8 +63,3 @@ Replace `andib/cira-dev:latest` with `YOUR_DOCKER_HUB_ACCOUNT/IMAGE_NAME:TAG` if
 ## Tests
 
 Run all tests via `pytest`.
-
-## Usage
-
-To use the CiRA pipeline, instantiate a `src.cira.CiRAConverter` object and specify the location of the pre-trained models.
-Then, use the high-level functionality as shown in the [demonstration.ipynb](./demonstration.ipynb) file.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ To use the CiRA pipeline, instantiate a `src.cira.CiRAConverter` object and spec
 
 ### REST API
 
-The CiRA functionality can also be provided by a single Docker container based on `Dockerfile`. Create the image and run the container via `docker-compose up --build`. The functionality can then be accessed at `localhost:8080`. Check `localhost:8080\docs` while the container is running to access the specification of the API.
+The CiRA functionality can also be provided by a single Docker container based on `Dockerfile`.
+Build and run the Docker container via `docker compose up`.
+CiRA's functionality can then be accessed at `localhost:8080`.
+Check `localhost:8080\docs` while the container is running to access the specification of the API.
 
 ### Building the cira-dev base image
 

--- a/app.py
+++ b/app.py
@@ -52,6 +52,8 @@ cira: CiRAService = None
 
 
 def setup_cira():
+    global cira
+
     # determine the location of the pre-trained models
     dotenv.load_dotenv()
     model_env_suffix = '_DEV' if ('DEV_CONTAINER' in os.environ) else ''
@@ -59,10 +61,7 @@ def setup_cira():
     model_labeling = os.environ[f'MODEL_LABELING{model_env_suffix}']
 
     # generate a CiRA service implementation
-    print(model_env_suffix)
-    print(model_classification)
     cira = CiRAServiceImpl(model_classification, model_labeling)
-    print(cira)
 
 
 class SentenceRequest(BaseModel):

--- a/app.py
+++ b/app.py
@@ -59,7 +59,10 @@ def setup_cira():
     model_labeling = os.environ[f'MODEL_LABELING{model_env_suffix}']
 
     # generate a CiRA service implementation
+    print(model_env_suffix)
+    print(model_classification)
     cira = CiRAServiceImpl(model_classification, model_labeling)
+    print(cira)
 
 
 class SentenceRequest(BaseModel):
@@ -101,7 +104,6 @@ def health():
 
 @app.get(PREFIX + '/classify', response_model=ClassificationResponse, tags=['classify'])
 async def create_classification(req: SentenceRequest):
-    print(cira)
     causal, confidence = cira.classify(req.sentence)
     return ClassificationResponse(causal=causal, confidence=confidence)
 
@@ -126,4 +128,4 @@ async def create_testsuite(req: SentenceRequest):
 
 if __name__ == '__main__':
     setup_cira()
-    uvicorn.run(app)
+    uvicorn.run(app, host='0.0.0.0')

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  cira:
+    container_name: cira
+    build: .
+    ports:
+      - "8080:8000"

--- a/test/app/test_app_integrated.py
+++ b/test/app/test_app_integrated.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from fastapi import status
 
-from src import app
+import app
 from src.api.service import CiRAServiceImpl
 
 sentence = "If the button is pressed then the system shuts down."

--- a/test/app/test_app_isolated.py
+++ b/test/app/test_app_isolated.py
@@ -3,7 +3,7 @@ import pytest
 from fastapi.testclient import TestClient
 from fastapi import status
 
-from src import app
+import app
 from src.api.service import CiraServiceMock
 
 sentence = "If the button is pressed then the system shuts down."


### PR DESCRIPTION
This PR closes #24. The API is now encapsulated in a singular Docker container, which runs the API on top of the dev image. 

The changes this PR entails are minimal except for the relocation of `app.py`, which has now been moved to the root folder. This way, the relative imports are resolved correctly without adjusting *all* imports. There might be a more elegant way to resolve this, but for now, this is good enough.

The naming of the service and container is still sub-optimal (right now, everything is labeled `cira`). In case a better solution exists, please propose a change.

Additionally, the organization of the README may require restructuring. This will be a task for the future.