### PR TITLE
Add workflow to publish the dev image

### DIFF
--- a/.github/workflows/docker-image-dev.yml
+++ b/.github/workflows/docker-image-dev.yml
@@ -1,0 +1,56 @@
+name: Publish Docker dev image
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-dev
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Cache model files
+        id: cache-models
+        uses: actions/cache@v3
+        with:
+          path: model/
+          key: zenodo-record-7186287
+          restore-keys: |
+            zenodo-record-7186287
+
+      - name: Download model files
+        run: |
+          chmod +x download-models.sh
+          ./download-models.sh
+          find model -name "*.zip" -delete
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.dev
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds a workflow that builds the dev image and publishes it in GitHub's Docker repository. 
The build images will be present in this repositorie's package view and its build is only manually triggered.

