### PR TITLE
Fix repository-must-be-lowercase on Docker CI build

### DIFF
--- a/.github/workflows/docker-image-dev.yml
+++ b/.github/workflows/docker-image-dev.yml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
@@ -52,5 +53,5 @@ jobs:
           context: .
           file: Dockerfile.dev
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.meta.outputs.tags}}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR fixes the [repository-must-be-lowercase](https://github.com/docker/build-push-action/blob/master/TROUBLESHOOTING.md#repository-name-must-be-lowercase) issue.

It runs on my repository 🙈. But since your GitHub name contains uppercases it causes an error when trying to push the Docker image to GitHub's Docker repository. 
See [run](https://github.com/JulianFrattini/cira/actions/runs/3465756451).