### PR TITLE
Make version explicit

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        pip install -r requirements.txt
+        pip install -e .
         
     - name: Test with pytest
       run: |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repostitory contains a Python implementation of the functions around the [c
 This package is built and tested using [Python 3.10.0](https://www.python.org/downloads/release/python-3100/). To use the CiRA pipeline locally, perform the following steps:
 
 1. Make sure the [Rust compiler](https://www.rust-lang.org/tools/install) is installed on your system, as the `tokenizer` package depends on it.
-2. Install all required dependencies via `pip3 install -r requirements.txt`.
+2. Install all required dependencies via `pip3 install -e .` or `pip3 install -r requirements.txt`.
 3. Download and unzip the pre-trained [classification and labeling models](https://doi.org/10.5281/zenodo.7186287) or use the `download-models.sh` script.
 4. Create a `.env` file and specify the variables `MODEL_CLASSIFICATION` and `MODEL_LABELING` with the location of the respective models.
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import os
 import dotenv
+import pkg_resources
+
 import uvicorn
 from fastapi import FastAPI, Request
 from pydantic import BaseModel
@@ -98,7 +100,11 @@ def root(req: Request):
 
 @app.get(PREFIX + "/health")
 def health():
-    return {"status": "up"}
+    cira_version = pkg_resources.require("cira")[0].version
+    return {
+        "status": "up",
+        "cira-version": cira_version
+    }
 
 
 @app.get(PREFIX + '/classify', response_model=ClassificationResponse, tags=['classify'])

--- a/app.py
+++ b/app.py
@@ -101,7 +101,6 @@ def root(req: Request):
 
 @app.get(PREFIX + "/health")
 def health():
-    global cira_version
     return {
         "status": "up",
         "cira-version": cira_version

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from src.api.service import CiRAService, CiRAServiceImpl
 
+cira_version = pkg_resources.require("cira")[0].version
 
 description = """The CiRA API wraps the functionality of the Causality in Requirements Artifacts initiative and bundles it in one easy-to-use API.
 
@@ -39,7 +40,7 @@ tags_metadata = [
 
 app = FastAPI(
     title="Causality in Requirements Artifacts - Pipeline",
-    version="1.0.0",
+    version=cira_version,
     description=description,
     contact={
         "name": "Julian Frattini",
@@ -100,7 +101,7 @@ def root(req: Request):
 
 @app.get(PREFIX + "/health")
 def health():
-    cira_version = pkg_resources.require("cira")[0].version
+    global cira_version
     return {
         "status": "up",
         "cira-version": cira_version

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='cira',
     author='Julian Frattini',
     author_email='juf@bth.se',
-    version='1.0.0',
+    version='0.9.0',
     description='Implementation of the Causality in Requirements Artifacts (CiRA) functionality',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup
+
+with open(file='README.md', mode='r') as readme_handler:
+    long_description = readme_handler.read()
+
+setup(
+    name='cira',
+    author='Julian Frattini',
+    author_email='juf@bth.se',
+    version='1.0.0',
+    description='Implementation of the Causality in Requirements Artifacts (CiRA) functionality',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    keywords=['nlp'],
+    url='https://github.com/JulianFrattini/cira',
+    python_requires='>=3.10',
+    install_requires=[
+        'numpy==1.23',
+        'python-dotenv==0.20',
+        'pytorch_lightning==1.7',
+        'tabulate==0.8.10',
+        'torch==1.12',
+        'transformers==4.10',
+        'uvicorn==0.18.3',
+        'fastapi==0.85.0',
+        'pydantic==1.10.2'
+    ],
+    extras_require = {
+        'dev': [
+            'pytest==7.1',
+            'pytest-cov==3.0'
+        ],
+    },
+)

--- a/test/app/test_app_isolated.py
+++ b/test/app/test_app_isolated.py
@@ -1,5 +1,7 @@
 import pytest
 
+import pkg_resources
+
 from fastapi.testclient import TestClient
 from fastapi import status
 
@@ -9,6 +11,7 @@ from src.api.service import CiraServiceMock
 sentence = "If the button is pressed then the system shuts down."
 API_URL = 'http://localhost:8000/api/'
 
+cira_version = pkg_resources.require("cira")[0].version
 
 @pytest.fixture(scope="module")
 def client() -> TestClient:
@@ -31,7 +34,10 @@ def test_health(client):
     response = client.get(f'{API_URL}health')
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {'status': 'up'}
+    assert response.json() == {
+        'status': 'up',
+        'cira-version': cira_version
+        }
 
 
 @pytest.mark.unit


### PR DESCRIPTION
This PR closes #30 by adding a standardized, explicit way of defining the version of the CiRA pipeline in a `setup.py` file. While [PEP 518](https://peps.python.org/pep-0518/) already supersedes the user of `setup.py` to build distributions, this initial approach at versioning will suffice for now.

The `requirements.txt` could be removed, but I left them in for now. I am however not opposed to fully removing it once the changes in the scope of this PR are deemed sufficient.