### PR TITLE
Extend app CI workflow to use CiRA version

### DIFF
--- a/.github/workflows/docker-image-app.yml
+++ b/.github/workflows/docker-image-app.yml
@@ -27,12 +27,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get CiRA version
+        run: |
+          CIRA_VERSION=$(python setup.py --version)
+          echo "CIRA_VERSION=$CIRA_VERSION" >> $GITHUB_ENV
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: latest
+          labels: |
+            org.opencontainers.image.version=${{ env.CIRA_VERSION }}
+          tags: |
+            latest
+            ${{ env.CIRA_VERSION }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
Uses the version information from `setup.py` to tag the Docker image.
The metadata of the Docker image will also include the CiRA version number by setting `org.opencontainers.image.version`.

![image](https://user-images.githubusercontent.com/9566732/202848478-f1ef3b09-550e-4ff0-8b10-80bca66a7871.png)
