### PR TITLE
Patch Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ghcr.io/julianfrattini/cira-dev:latest
 
 WORKDIR /cira
 
-# Install missing Python dependencies
-COPY requirements.txt .
-RUN pip3 install -r requirements.txt
+# Install Python dependencies and setup cira version
+COPY setup.py .
+RUN pip3 install -e .
 
 COPY ./src ./src
 COPY ./app.py ./app.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /cira
 
 # Install Python dependencies and setup cira version
 COPY setup.py .
+COPY README.md .
 RUN pip3 install -e .
+
+# Set DEV_CONTAINER to true such that the code references the models in the container
+ENV DEV_CONTAINER=TRUE
 
 COPY ./src ./src
 COPY ./app.py ./app.py


### PR DESCRIPTION
This PR substitutes `pip install -r requirements` for `pip install -e .` just as proposed in #34. 