### PR TITLE
Adjust http methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/app.py
+++ b/app.py
@@ -107,25 +107,25 @@ def health():
     }
 
 
-@app.post(PREFIX + '/classify', response_model=ClassificationResponse, tags=['classify'])
+@app.put(PREFIX + '/classify', response_model=ClassificationResponse, tags=['classify'])
 async def create_classification(req: SentenceRequest):
     causal, confidence = cira.classify(req.sentence)
     return ClassificationResponse(causal=causal, confidence=confidence)
 
 
-@app.post(PREFIX + '/label', response_model=LabelingResponse, tags=['label'])
+@app.put(PREFIX + '/label', response_model=LabelingResponse, tags=['label'])
 async def create_labels(req: SentenceRequest):
     labels = cira.sentence_to_labels(sentence=req.sentence)
     return LabelingResponse(labels=labels)
 
 
-@app.post(PREFIX + '/graph', response_model=GraphResponse, tags=['graph'])
+@app.put(PREFIX + '/graph', response_model=GraphResponse, tags=['graph'])
 async def create_graph(req: SentenceRequest):
     graph = cira.sentence_to_graph(sentence=req.sentence, labels=req.labels)
     return GraphResponse(graph=graph)
 
 
-@app.post(PREFIX + '/testsuite', response_model=TestsuiteResponse, tags=['testsuite'])
+@app.put(PREFIX + '/testsuite', response_model=TestsuiteResponse, tags=['testsuite'])
 async def create_testsuite(req: SentenceRequest):
     testsuite = cira.graph_to_test(graph=req.graph, sentence=req.sentence)
     return TestsuiteResponse(suite=testsuite)

--- a/app.py
+++ b/app.py
@@ -107,25 +107,25 @@ def health():
     }
 
 
-@app.get(PREFIX + '/classify', response_model=ClassificationResponse, tags=['classify'])
+@app.post(PREFIX + '/classify', response_model=ClassificationResponse, tags=['classify'])
 async def create_classification(req: SentenceRequest):
     causal, confidence = cira.classify(req.sentence)
     return ClassificationResponse(causal=causal, confidence=confidence)
 
 
-@app.get(PREFIX + '/label', response_model=LabelingResponse, tags=['label'])
+@app.post(PREFIX + '/label', response_model=LabelingResponse, tags=['label'])
 async def create_labels(req: SentenceRequest):
     labels = cira.sentence_to_labels(sentence=req.sentence)
     return LabelingResponse(labels=labels)
 
 
-@app.get(PREFIX + '/graph', response_model=GraphResponse, tags=['graph'])
+@app.post(PREFIX + '/graph', response_model=GraphResponse, tags=['graph'])
 async def create_graph(req: SentenceRequest):
     graph = cira.sentence_to_graph(sentence=req.sentence, labels=req.labels)
     return GraphResponse(graph=graph)
 
 
-@app.get(PREFIX + '/testsuite', response_model=TestsuiteResponse, tags=['testsuite'])
+@app.post(PREFIX + '/testsuite', response_model=TestsuiteResponse, tags=['testsuite'])
 async def create_testsuite(req: SentenceRequest):
     testsuite = cira.graph_to_test(graph=req.graph, sentence=req.sentence)
     return TestsuiteResponse(suite=testsuite)

--- a/test/app/test_app_integrated.py
+++ b/test/app/test_app_integrated.py
@@ -56,7 +56,7 @@ def client() -> TestClient:
 
 @pytest.mark.system
 def test_classification(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}classify', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -68,7 +68,7 @@ def test_classification(client):
 
 @pytest.mark.system
 def test_classification_empty_sentence(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}classify', json={"sentence": ""})
 
     assert response.status_code == status.HTTP_200_OK
@@ -80,7 +80,7 @@ def test_classification_empty_sentence(client):
 
 @pytest.mark.system
 def test_classification_missing_sentence(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}classify', json={})
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -88,19 +88,19 @@ def test_classification_missing_sentence(client):
 
 @pytest.mark.system
 def test_classification_missing_sentence_recovery(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}classify', json={})
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # assert that after a failed request a valid request will succeed
-    response = client.get(
+    response = client.post(
         f'{API_URL}classify', json={"sentence": sentence})
     assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.system
 def test_labeling(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}label', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -111,7 +111,7 @@ def test_labeling(client):
 
 @pytest.mark.system
 def test_labeling_emtpy_sentence(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}label', json={"sentence": ""})
 
     assert response.status_code == status.HTTP_200_OK
@@ -122,7 +122,7 @@ def test_labeling_emtpy_sentence(client):
 
 @pytest.mark.system
 def test_graph(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}graph', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -133,7 +133,7 @@ def test_graph(client):
 
 @pytest.mark.system
 def test_suite(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}testsuite', json={"sentence": sentence, "graph": graph})
 
     assert response.status_code == status.HTTP_200_OK
@@ -144,7 +144,7 @@ def test_suite(client):
 
 @pytest.mark.system
 def test_suite_missing_graph(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}testsuite', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK

--- a/test/app/test_app_integrated.py
+++ b/test/app/test_app_integrated.py
@@ -56,7 +56,7 @@ def client() -> TestClient:
 
 @pytest.mark.system
 def test_classification(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}classify', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -68,7 +68,7 @@ def test_classification(client):
 
 @pytest.mark.system
 def test_classification_empty_sentence(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}classify', json={"sentence": ""})
 
     assert response.status_code == status.HTTP_200_OK
@@ -80,7 +80,7 @@ def test_classification_empty_sentence(client):
 
 @pytest.mark.system
 def test_classification_missing_sentence(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}classify', json={})
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -88,19 +88,19 @@ def test_classification_missing_sentence(client):
 
 @pytest.mark.system
 def test_classification_missing_sentence_recovery(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}classify', json={})
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # assert that after a failed request a valid request will succeed
-    response = client.post(
+    response = client.put(
         f'{API_URL}classify', json={"sentence": sentence})
     assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.system
 def test_labeling(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}label', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -111,7 +111,7 @@ def test_labeling(client):
 
 @pytest.mark.system
 def test_labeling_emtpy_sentence(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}label', json={"sentence": ""})
 
     assert response.status_code == status.HTTP_200_OK
@@ -122,7 +122,7 @@ def test_labeling_emtpy_sentence(client):
 
 @pytest.mark.system
 def test_graph(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}graph', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -133,7 +133,7 @@ def test_graph(client):
 
 @pytest.mark.system
 def test_suite(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}testsuite', json={"sentence": sentence, "graph": graph})
 
     assert response.status_code == status.HTTP_200_OK
@@ -144,7 +144,7 @@ def test_suite(client):
 
 @pytest.mark.system
 def test_suite_missing_graph(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}testsuite', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK

--- a/test/app/test_app_isolated.py
+++ b/test/app/test_app_isolated.py
@@ -42,7 +42,7 @@ def test_health(client):
 
 @pytest.mark.unit
 def test_classification(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}classify', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -51,7 +51,7 @@ def test_classification(client):
 
 @pytest.mark.unit
 def test_labels(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}label', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -61,7 +61,7 @@ def test_labels(client):
 
 @pytest.mark.unit
 def test_graph(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}graph', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -77,7 +77,7 @@ def test_graph(client):
 
 @pytest.mark.unit
 def test_suite(client):
-    response = client.post(
+    response = client.put(
         f'{API_URL}testsuite', json={"sentence": sentence, "graph": None})
 
     assert response.status_code == status.HTTP_200_OK

--- a/test/app/test_app_isolated.py
+++ b/test/app/test_app_isolated.py
@@ -42,7 +42,7 @@ def test_health(client):
 
 @pytest.mark.unit
 def test_classification(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}classify', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -51,7 +51,7 @@ def test_classification(client):
 
 @pytest.mark.unit
 def test_labels(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}label', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -61,7 +61,7 @@ def test_labels(client):
 
 @pytest.mark.unit
 def test_graph(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}graph', json={"sentence": sentence})
 
     assert response.status_code == status.HTTP_200_OK
@@ -77,7 +77,7 @@ def test_graph(client):
 
 @pytest.mark.unit
 def test_suite(client):
-    response = client.get(
+    response = client.post(
         f'{API_URL}testsuite', json={"sentence": sentence, "graph": None})
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
This PR closes #40 by changing all API endpoints that require a body and are currently defined as GET methods to POST methods. Test cases are adjusted accordingly.