### PR TITLE
Specify pythonpath in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,9 @@ addopts =
     --cov=src
     -s
     -vv
+pythonpath =
+    .
+    src
 testpaths =
     test
 markers =   


### PR DESCRIPTION
This PR specifies the `pythonpath` setting in `pytest.ini` to avoid problems within Docker containers.

Without this setting it is not possible to run `pytest` within the `cira-dev` image since it is not able to resolve some of the Python modules.