### PR TITLE
Patch selection of the first cause

### DIFF
--- a/src/converters/labelstograph/eventconnector.py
+++ b/src/converters/labelstograph/eventconnector.py
@@ -45,8 +45,8 @@ def get_junctors(events: list[EventNode]) -> dict:
     
     junctor_map = {}
 
-    # get the starting node (the cause event node which has no predecessor)
-    current_node: EventNode = [event for event in events if (event.labels[0].predecessor == None)][0]
+    # get the starting node (the cause event node associated to the event label with the lowest begin index)
+    current_node: EventNode = sorted(events, key=lambda event: event.labels[0].begin, reverse=False)[0]
     while current_node.labels[-1].successor != None:
         label1 = current_node.labels[-1]
         label2 = label1.successor.target

--- a/test/converters/labelstograph/eventconnector/test_junctor_map.py
+++ b/test/converters/labelstograph/eventconnector/test_junctor_map.py
@@ -67,3 +67,19 @@ def test_overruled_precedence():
 
     junctors = get_junctors(events=nodes)
     assert junctors[('E2', 'E3')] == 'POR'
+
+@pytest.mark.unit
+def test_causes_after_events():
+    e1 = EventLabel(id='L1', name='Effect1', begin=0, end = 10)
+    c1 = EventLabel(id='L2', name='Cause1', begin=15, end=20)
+    c2 = EventLabel(id='L3', name='Cause2', begin=25, end=30)
+    e1.set_successor(successor=c1, junctor=None)
+    c1.set_successor(successor=c2, junctor='OR')
+
+    causes = [ 
+        EventNode(id='E2', labels=[c1]), 
+        EventNode(id='E3', labels=[c2])]
+
+    junctors = get_junctors(events=causes)
+    print(junctors)
+    assert junctors[('E2', 'E3')] == 'OR'


### PR DESCRIPTION
This PR closes #62 by replacing the identification of the first cause event node: instead of relying on the absence of a predecessor, it not relies on the lowest `begin` index of the associated event labels. This method is robust in the case that the first event of a sentence is an effect instead of a cause.