### PR TITLE
Made CORS rules permissive

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ PREFIX = "/api"
 # add CORS middleware allowing all requests from the same localhost
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex='*',
+    allow_origins=['*'],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"]

--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ PREFIX = "/api"
 # add CORS middleware allowing all requests from the same localhost
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex='http://localhost:.*',
+    allow_origin_regex='*',
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='cira',
     author='Julian Frattini',
     author_email='juf@bth.se',
-    version='0.9.6',
+    version='0.9.7',
     description='Implementation of the Causality in Requirements Artifacts (CiRA) functionality',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
To make requests from outside available, the CORS header now allows everything. There could be a more elegant, configurable version down the road but this version suffices for now.