### PR TITLE
Refactor graph converter to use consts and improve readability

### DIFF
--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -23,3 +23,5 @@ AND = 'AND'
 POR = 'POR'
 
 NOTRELEVANT = 'notrelevant'
+
+NEGATION = 'Negation'


### PR DESCRIPTION
This PR changes `graphconverter.py` by using constants instead of hard-coded strings (issue #44).
In addition, parts of the code were refactored to improve its readability.