### PR TITLE
Refactor sentencetolabels package to use consts

### DIFF
--- a/src/converters/sentencetolabels/labelrecovery.py
+++ b/src/converters/sentencetolabels/labelrecovery.py
@@ -13,7 +13,6 @@ def recover_labels(sentence: str, labels: list[Label]) -> list[Label]:
 
     return labels
 
-EXCEPTIVE_CLAUSES = ['unless']
 def label_exceptive_clauses(sentence: str, labels: list[Label]) -> list[SubLabel]:
     """Identify all instances of exceptive clauses (determined by the list of words above) that have not been labeled. Because exceptive clauses like this are very rare they have apparently not been picked up by the BERT-based labeler. Because they convey important information ("Unless A then B" translates to "If not A then B") they need to be recovered. This method generates a negation for each exceptive clause that does not yet contain one.
 
@@ -26,7 +25,7 @@ def label_exceptive_clauses(sentence: str, labels: list[Label]) -> list[SubLabel
     additional_labels: list[SubLabel] = []
 
     exceptive_instances = []
-    for exclause in EXCEPTIVE_CLAUSES:
+    for exclause in consts.EXCEPTIVE_CLAUSES:
         iter = re.finditer(exclause, sentence.lower())
         exceptive_instances += [m.span() for m in iter]
 

--- a/src/converters/sentencetolabels/labelrecovery.py
+++ b/src/converters/sentencetolabels/labelrecovery.py
@@ -1,7 +1,8 @@
 import re
 
-from src.data.labels import Label, EventLabel, SubLabel
-from src.data.labels import get_label_by_type_and_position
+import src.util.constants as consts
+from src.data.labels import Label, SubLabel, get_label_by_type_and_position
+
 
 def recover_labels(sentence: str, labels: list[Label]) -> list[Label]:
     """The capabilities of the BERT-based sentence labeler are limited. Because some sentence structures are more rare than others (e.g., exceptive clauses), the labeler might miss important information. This method manually recovers certain labels according to specific patterns and updates the list of labels currently associated with the sentence
@@ -10,16 +11,16 @@ def recover_labels(sentence: str, labels: list[Label]) -> list[Label]:
     for add_labels in [label_exceptive_clauses]:
         labels += add_labels(sentence, labels)
 
-    return labels 
+    return labels
 
 EXCEPTIVE_CLAUSES = ['unless']
 def label_exceptive_clauses(sentence: str, labels: list[Label]) -> list[SubLabel]:
     """Identify all instances of exceptive clauses (determined by the list of words above) that have not been labeled. Because exceptive clauses like this are very rare they have apparently not been picked up by the BERT-based labeler. Because they convey important information ("Unless A then B" translates to "If not A then B") they need to be recovered. This method generates a negation for each exceptive clause that does not yet contain one.
-    
+
     parameters:
         sentence -- natural language sentence
         labels -- list of labels already associated with the sentence
-        
+
     returns: list of labels for previously unlabeled exceptive clauses"""
 
     additional_labels: list[SubLabel] = []
@@ -30,8 +31,11 @@ def label_exceptive_clauses(sentence: str, labels: list[Label]) -> list[SubLabel
         exceptive_instances += [m.span() for m in iter]
 
     for index, instance in enumerate(exceptive_instances):
-        label = get_label_by_type_and_position(labels, type='Negation', begin=instance[0], end=instance[1])
-        if label == None:
-            additional_labels.append(SubLabel(id=f'AEX{index}', name='Negation', begin=instance[0], end=instance[1]))
+        label = get_label_by_type_and_position(labels, type=consts.NEGATION, begin=instance[0], end=instance[1])
+        if label is None:
+            additional_labels.append(
+                SubLabel(id=f'AEX{index}', name=consts.NEGATION, begin=instance[0], end=instance[1])
+            )
 
     return additional_labels
+

--- a/src/converters/sentencetolabels/model.py
+++ b/src/converters/sentencetolabels/model.py
@@ -1,12 +1,11 @@
-from torch.nn import BCEWithLogitsLoss
-from torch import nn
-from transformers.modeling_outputs import TokenClassifierOutput
-from transformers import RobertaModel
+import abc
 
 import pytorch_lightning as pl
 import torch
-import torch.nn as nn
-import abc
+from torch import nn
+from torch.nn import BCEWithLogitsLoss
+from transformers import RobertaModel
+from transformers.modeling_outputs import TokenClassifierOutput
 
 
 class CustomModel(pl.LightningModule):

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -23,3 +23,5 @@ AND = 'AND'
 POR = 'POR'
 
 NOTRELEVANT = 'notrelevant'
+
+NEGATION = 'Negation'

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -3,6 +3,9 @@ SENTENCES_PATH = './static/sentences'
 LABEL_IDS = ['NOT_RELEVANT', 'CAUSE_1', 'CAUSE_2', 'CAUSE_3', 'EFFECT_1', 'EFFECT_2', 'EFFECT_3', 'AND', 'OR', 'VARIABLE', 'CONDITION', 'NEGATION']
 LABEL_IDS_VERBOSE = ['notrelevant', 'Cause1', 'Cause2', 'Cause3', 'Effect1', 'Effect2', 'Effect3', 'Conjunction', 'Disjunction', 'Variable', 'Condition', 'Negation']
 
+UNLESS = 'unless'
+EXCEPTIVE_CLAUSES = [UNLESS]
+
 # Event
 CAUSE = 'Cause'
 EFFECT = 'Effect'


### PR DESCRIPTION
This PR changes graphconverter.py by using constants instead of hard-coded strings (issue #44).
In addition, parts of the code were refactored to improve its readability.

- Organize imports using isort
- Extract magic numbers into consts
- Remove trailing whitespaces 